### PR TITLE
implement penalized likelihood ratio tests to calculate p-values

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,7 @@
 # firthlogist
 
 [![PyPI](https://img.shields.io/pypi/v/firthlogist.svg)](https://pypi.org/project/firthlogist/)
+[![GitHub](https://img.shields.io/github/license/jzluo/firthlogist)](https://github.com/jzluo/firthlogist/blob/master/LICENSE)
 
 A Python implementation of Logistic Regression with Firth's bias reduction.
 

--- a/README.md
+++ b/README.md
@@ -14,9 +14,12 @@ firthlogist follows the sklearn API.
 
 ```python
 from firthlogist import FirthLogisticRegression
+
 firth = FirthLogisticRegression()
 firth.fit(X, y)
 coefs = firth.coef_
+pvals = firth.pvals_
+bse = firth.bse_
 ```
 
 ## References

--- a/firthlogist/firthlogist.py
+++ b/firthlogist/firthlogist.py
@@ -34,6 +34,8 @@ class FirthLogisticRegression(BaseEstimator, ClassifierMixin):
 
     Attributes
     ----------
+    bse_
+        Standard errors of the coefficients.
     classes_
         A list of the class labels.
     coef_
@@ -42,6 +44,8 @@ class FirthLogisticRegression(BaseEstimator, ClassifierMixin):
         Fitted intercept. If `fit_intercept = False`, the intercept is set to zero.
     n_iter_
         Number of Newton-Raphson iterations performed.
+    pvals_
+        p-values calculated by penalized likelihood ratio tests.
 
     References
     ----------

--- a/firthlogist/firthlogist.py
+++ b/firthlogist/firthlogist.py
@@ -81,6 +81,11 @@ class FirthLogisticRegression(BaseEstimator, ClassifierMixin):
                 f"Maximum number of iterations must be positive; "
                 f"got max_iter={self.max_iter}"
             )
+        if self.max_halfstep < 0:
+            raise ValueError(
+                f"Maximum number of step-halvings must >= 0; "
+                f"got max_halfstep={self.max_iter}"
+            )
         if self.tol < 0:
             raise ValueError(
                 f"Tolerance for stopping criteria must be positive; got tol={self.tol}"
@@ -109,6 +114,7 @@ class FirthLogisticRegression(BaseEstimator, ClassifierMixin):
         # penalized likelihood ratio tests
         if not self.skip_lrt:
             pvals = []
+            # mask is 1-indexed because of `if mask` check in _get_XW()
             for mask in range(1, self.coef_.shape[0] + 1):
                 _, null_loglik, _ = _firth_newton_raphson(
                     X,

--- a/firthlogist/firthlogist.py
+++ b/firthlogist/firthlogist.py
@@ -31,6 +31,9 @@ class FirthLogisticRegression(BaseEstimator, ClassifierMixin):
         Convergence tolerance for stopping.
     fit_intercept
         Specifies if intercept should be added.
+    skip_lrt
+        If True, p-values will not be calculated. Calculating the p-values can be
+        expensive since the fitting procedure is repeated for each coefficient.
 
     Attributes
     ----------

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "firthlogist"
-version = "0.0.4"
+version = "0.1.0"
 description = "Python implementation of Logistic Regression with Firth's bias reduction"
 authors = ["Jon Luo <jzluo@alumni.cmu.edu>"]
 repository = "https://github.com/jzluo/firthlogist"


### PR DESCRIPTION
In logistf, likelihood ratio test statistics are not calculated by excluding the parameter being tested when fitting the null model. Instead the coefficient is constrained to zero such that it still contributes to the penalization (see https://stats.stackexchange.com/questions/555971/calculation-of-p-values-in-logistf-package)

[In the logistf code](https://github.com/georgheinze/logistf/blob/c48894acc2d6309cb261cb01145ae4f19265494d/src/logistf.c#L150-L176), it seems this is done in the calculation of `XW^(1/2)`,  going by where `selcol` appears. So I implemented a masking in `_get_XW()`.

There's some minor discrepancies in the p-values compared to logistf. Need to look into that but it's fine for now.

| package | Intercept | age | oc | vic | vicl | vis | dia |
| ----------- | ----------- | ----- | ---- | ---- | ---- | --- | --- |
| **logistf** | 8.020268e-01 | 6.143472e-03 | 8.751911e-01 | 1.678877e-06 | 1.237805e-05 | 5.449701e-02 | 4.951873e-03 |
| **firthlogist** | 7.66583794e-01 | 6.11138932e-03 | 8.26365363e-01 | 1.67218633e-06 | 1.23618050e-05 | 5.34899080e-02 | 4.84687363e-03 |