### PR TITLE
10 wald test and confidence intervals

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Test for profile likelihood confidence intervals ([#9](https://github.com/jzluo/firthlogist/pull/9)).
 ### Changed
 - `skip_lrt` option is now `skip_pvals`.
+### Fixed
+- `.summary()` no longer breaks if skipping confidence interval or p-value calculation.
 ### Removed
 - Diabetes and sex2 csv files removed from testing dir ([#9](https://github.com/jzluo/firthlogist/pull/9)).
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,7 +12,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 - `skip_lrt` option is now `skip_pvals`.
 ### Removed
-- Diabetes and sex2 csv files removed from testing dir ([#9](([#9](https://github.com/jzluo/firthlogist/pull/9))).
+- Diabetes and sex2 csv files removed from testing dir ([#9](https://github.com/jzluo/firthlogist/pull/9)).
 
 ## [0.3.1] - 2022-07-29
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,14 +5,17 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+
+## [0.4.0] - 2022-08-01
+
 ### Added
-- Option to use Wald method for computing p-values and confidence intervals instead of LRT and profile likelihood. Set `wald=True` to use.
+- Option to use Wald method for computing p-values and confidence intervals instead of LRT and profile likelihood. Set `wald=True` to use ([#11](https://github.com/jzluo/firthlogist/pull/11)).
 - Tests for `load_sex2()` and `load_endometrial()` ([#9](https://github.com/jzluo/firthlogist/pull/9)).
 - Test for profile likelihood confidence intervals ([#9](https://github.com/jzluo/firthlogist/pull/9)).
 ### Changed
-- `skip_lrt` option is now `skip_pvals`.
+- `skip_lrt` option is now `skip_pvals` ([#11](https://github.com/jzluo/firthlogist/pull/11)).
 ### Fixed
-- `.summary()` no longer breaks if skipping confidence interval or p-value calculation.
+- `.summary()` no longer breaks if skipping confidence interval or p-value calculation ([#11](https://github.com/jzluo/firthlogist/pull/11)).
 ### Removed
 - Diabetes and sex2 csv files removed from testing dir ([#9](https://github.com/jzluo/firthlogist/pull/9)).
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,8 +6,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 ### Added
+- Option to use Wald method for computing p-values and confidence intervals instead of LRT and profile likelihood. Set `wald=True` to use.
 - Tests for `load_sex2()` and `load_endometrial()` ([#9](https://github.com/jzluo/firthlogist/pull/9)).
 - Test for profile likelihood confidence intervals ([#9](https://github.com/jzluo/firthlogist/pull/9)).
+### Changed
+- `skip_lrt` option is now `skip_pvals`.
 ### Removed
 - Diabetes and sex2 csv files removed from testing dir ([#9](([#9](https://github.com/jzluo/firthlogist/pull/9))).
 

--- a/README.md
+++ b/README.md
@@ -70,16 +70,23 @@ be less than max_stepsize.
 
 &emsp;Specifies if intercept should be added.
 
-`skip_lrt`: **_bool_, default=False**
+`skip_pvals`: **_bool_, default=False**
 
 &emsp;If True, p-values will not be calculated. Calculating the p-values can
-be expensive since the fitting procedure is repeated for each
+be expensive if `wald=False` since the fitting procedure is repeated for each
 coefficient.
 
 `skip_ci`: **_bool_, default=False**
 
 &emsp;If True, confidence intervals will not be calculated. Calculating the confidence intervals via profile likelihoood is time-consuming.
 
+`alpha`: **_float_, default=0.05**
+
+&emsp;Significance level (confidence interval = 1-alpha). 0.05 as default for 95% CI.
+
+`wald`: **_bool_, default=False**
+
+&emsp;If True, uses Wald method to calculate p-values and confidence intervals.
 
 ### Attributes
 `bse_`

--- a/firthlogist/firthlogist.py
+++ b/firthlogist/firthlogist.py
@@ -43,7 +43,7 @@ class FirthLogisticRegression(BaseEstimator, ClassifierMixin):
         Convergence tolerance for stopping.
     fit_intercept
         Specifies if intercept should be added.
-    skip_lrt
+    skip_pvals
         If True, p-values will not be calculated. Calculating the p-values can be
         time-consuming since the fitting procedure is repeated for each coefficient.
     skip_ci
@@ -51,6 +51,8 @@ class FirthLogisticRegression(BaseEstimator, ClassifierMixin):
         intervals via profile likelihoood is time-consuming.
     alpha
         Significance level (confidence interval = 1-alpha). 0.05 as default for 95% CI.
+    wald
+        If True, uses Wald method to calculate p-values and confidence intervals.
 
     Attributes
     ----------
@@ -90,7 +92,7 @@ class FirthLogisticRegression(BaseEstimator, ClassifierMixin):
         pl_max_stepsize=5,
         tol=0.0001,
         fit_intercept=True,
-        skip_lrt=False,
+        skip_pvals=False,
         skip_ci=False,
         alpha=0.05,
         wald=False,
@@ -103,7 +105,7 @@ class FirthLogisticRegression(BaseEstimator, ClassifierMixin):
         self.pl_max_stepsize = pl_max_stepsize
         self.tol = tol
         self.fit_intercept = fit_intercept
-        self.skip_lrt = skip_lrt
+        self.skip_pvals = skip_pvals
         self.skip_ci = skip_ci
         self.alpha = alpha
         self.wald = wald
@@ -170,7 +172,7 @@ class FirthLogisticRegression(BaseEstimator, ClassifierMixin):
                 self.ci_ = _wald_ci(self.coef_, self.bse_, self.alpha)
 
         # penalized likelihood ratio tests
-        if not self.skip_lrt:
+        if not self.skip_pvals:
             if not self.wald:
                 pvals = []
                 # mask is 1-indexed because of `if mask` check in _get_XW()

--- a/firthlogist/firthlogist.py
+++ b/firthlogist/firthlogist.py
@@ -45,7 +45,8 @@ class FirthLogisticRegression(BaseEstimator, ClassifierMixin):
         Specifies if intercept should be added.
     skip_pvals
         If True, p-values will not be calculated. Calculating the p-values can be
-        time-consuming since the fitting procedure is repeated for each coefficient.
+        time-consuming if `wald=False` since the fitting procedure is repeated for each
+        coefficient.
     skip_ci
         If True, confidence intervals will not be calculated. Calculating the confidence
         intervals via profile likelihoood is time-consuming.

--- a/firthlogist/firthlogist.py
+++ b/firthlogist/firthlogist.py
@@ -170,6 +170,8 @@ class FirthLogisticRegression(BaseEstimator, ClassifierMixin):
                 )
             else:
                 self.ci_ = _wald_ci(self.coef_, self.bse_, self.alpha)
+        else:
+            self.ci_ = np.full((self.coef_.shape[0], 2), np.nan)
 
         # penalized likelihood ratio tests
         if not self.skip_pvals:
@@ -191,6 +193,8 @@ class FirthLogisticRegression(BaseEstimator, ClassifierMixin):
 
             else:
                 self.pvals_ = _wald_test(self.coef_, self.bse_)
+        else:
+            self.pvals_ = np.full(self.coef_.shape[0], np.nan)
 
         if self.fit_intercept:
             self.intercept_ = self.coef_[-1]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "firthlogist"
-version = "0.3.1"
+version = "0.4.0"
 description = "Python implementation of Logistic Regression with Firth's bias reduction"
 authors = ["Jon Luo <jzluo@alumni.cmu.edu>"]
 repository = "https://github.com/jzluo/firthlogist"


### PR DESCRIPTION
This PR adds the option to use Wald method for p-values and confidence intervals instead of penalized likelihood ratio tests and profile penalized likelihood.