### PR TITLE
In QR decomp for _hat_diag, enable overwrite_a

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Changed
+- Small tweak to QR decomposition lapack call -> overall runtime and memory usage improvement of ~24% and 19%, respectively. Oops.
 
 ## [0.5.0] - 2022-08-07
 ### Added

--- a/firthlogist/firthlogist.py
+++ b/firthlogist/firthlogist.py
@@ -343,9 +343,8 @@ def _get_aug_XW(X, preds, hats):
 
 def _hat_diag(XW):
     # Get diagonal elements of the hat matrix
-    # Q = np.linalg.qr(XW, mode="reduced")[0]
-    qr, tau, _, _ = lapack.dgeqrf(XW)
-    Q, _, _ = lapack.dorgqr(qr, tau)
+    qr, tau, _, _ = lapack.dgeqrf(XW, overwrite_a=True)
+    Q, _, _ = lapack.dorgqr(qr, tau, overwrite_a=True)
     hat = np.einsum("ij,ij->i", Q, Q)
     return hat
 


### PR DESCRIPTION
It's safe to overwrite `XW` each time we call `_hat_diag()`, so we should. This improved total runtime by ~24% and decreased memory usage by 19% on one dataset I tested.