### PR TITLE
Use fast_logdet to compute penalty

### DIFF
--- a/firthlogist/firthlogist.py
+++ b/firthlogist/firthlogist.py
@@ -10,6 +10,7 @@ from scipy.stats import chi2, norm
 from sklearn.base import BaseEstimator, ClassifierMixin
 from sklearn.exceptions import ConvergenceWarning
 from sklearn.preprocessing import LabelEncoder
+from sklearn.utils.extmath import fast_logdet
 from sklearn.utils.multiclass import check_classification_targets
 from sklearn.utils.validation import check_is_fitted
 from tabulate import tabulate
@@ -319,7 +320,9 @@ def _loglikelihood(X, y, preds):
     # penalized log-likelihood
     XW = _get_XW(X, preds)
     fisher_info_mtx = XW.T @ XW
-    penalty = 0.5 * np.log(np.linalg.det(fisher_info_mtx))
+    penalty = 0.5 * fast_logdet(fisher_info_mtx)
+    if not np.isfinite(penalty):
+        penalty = 0
     return -1 * (np.sum(y * np.log(preds) + (1 - y) * np.log(1 - preds)) + penalty)
 
 


### PR DESCRIPTION
Trying to fix #17.
The optimization now uses `scipy.utils.extmath.fast_logdet` instead of `np.log(np.linalg.det())`.

In case of a negative determinant, the penalty is being set to 0.
Is that correct @jzluo? How should negative determinants be handled?